### PR TITLE
delete notifications linked to deleted post

### DIFF
--- a/models/notifications.js
+++ b/models/notifications.js
@@ -39,6 +39,8 @@ async function findByUserId(user_id) {
             ...note,
             content: reply.reply_content
           });
+        } else {
+          await remove(note.id);
         }
       } else if (note.type === "like" || note.type === "reply") {
         const post = await Posts.find({ "p.id": note.type_id }).first();
@@ -47,6 +49,8 @@ async function findByUserId(user_id) {
             ...note,
             content: post.post_content
           });
+        } else {
+          await remove(note.id);
         }
       }
       return acc;


### PR DESCRIPTION
# Description

Describe change or new feature here.

deleted posts now delete old notifications attached to it 
## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works AND the tests pass
